### PR TITLE
remove Debian's 127.0.1.1 entry for fqdn

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -147,14 +147,6 @@ class hosts (
     }
   }
 
-  # On Debian based systems an entry for the fqdn with an alias of the hostname
-  # and IP of 127.0.1.1 is expected.
-  if $::osfamily == 'Debian' {
-    $fqdn_ip_real = '127.0.1.1'
-  } else {
-    $fqdn_ip_real = $fqdn_ip
-  }
-
   case $purge_hosts_enabled {
     true, false: { }
     default: {
@@ -185,7 +177,7 @@ class hosts (
   @@host { $::fqdn:
     ensure       => $fqdn_ensure,
     host_aliases => $my_fqdn_host_aliases,
-    ip           => $fqdn_ip_real,
+    ip           => $fqdn_ip,
   }
 
   # only collect the exported entry above


### PR DESCRIPTION
According to the documentation:
"The Debian Installer creates this entry for a system without a permanent IP address as a workaround for some software (e.g., GNOME) as documented in the bug #316099.".

So it's not needed (or even not acceptable) when a host has IP address assigned.
Maybe it would be better to check if the IP address is assigned and make a decision based on that, but on the other hand, do we really need that check...?
