### PR TITLE
add an option to collect all the exported Host resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,9 @@ target
 String for path to hosts file
 
 - *Default*: /etc/hosts
+
+collect_all
+-----------
+Boolean to optionally collect all the exported Host resources from puppetdb
+
+- *Default*: false 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,6 +52,12 @@
 #
 # - *Default*: /etc/hosts
 #
+# collect_all
+# -----------
+# Boolean to optionally collect all the exported Host resources from puppetdb
+#
+# - *Default*: false
+#
 class hosts (
   $enable_ipv4_localhost = true,
   $enable_ipv6_localhost = true,


### PR DESCRIPTION
this pull request doesn't change the default behaviour (that is to collect only host's own fqdn).
