### PR TITLE
Support rspec-puppet v1.0.0

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -259,7 +259,7 @@ describe 'hosts' do
 
       it 'should fail' do
         expect {
-          should include_class('hosts')
+          should contain_class('hosts')
         }.to raise_error(Puppet::Error,/hosts::localhost_aliases must be a string or an array. Detected type is <boolean>./)
       end
     end
@@ -351,7 +351,7 @@ describe 'hosts' do
 
       it 'should fail' do
         expect {
-          should include_class('hosts')
+          should contain_class('hosts')
         }.to raise_error(Puppet::Error,/hosts::localhost6_aliases must be a string or an array. Detected type is <boolean>./)
       end
     end
@@ -467,7 +467,7 @@ describe 'hosts' do
 
     it 'should fail' do
       expect {
-        should include_class('hosts')
+        should contain_class('hosts')
       }.to raise_error(Puppet::Error)
     end
   end


### PR DESCRIPTION
include_class has been replaced with contain_class.
http://bombasticmonkey.com/2013/12/05/rspec-puppet-1.0.0/
