### PR TITLE
Use fqdn

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ Boolean to enable entry for fqdn
 
 - *Default*: true
 
+use_fqdn
+--------
+When enabled use the ${::fqdn} fact to determine the hosts entry for the local node.
+
+- *Default*: true
+
 fqdn_host_aliases
 -----------------
 String or Array of aliases for fqdn

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,6 +53,14 @@ class hosts (
   }
 
   # validate type and convert string to boolean if necessary
+  $use_fqdn_type = type($use_fqdn)
+  if $use_fqdn_type == 'string' {
+    $use_fqdn_real = str2bool($use_fqdn)
+  } else {
+    $use_fqdn_real = $use_fqdn
+  }
+
+  # validate type and convert string to boolean if necessary
   $purge_hosts_type = type($purge_hosts)
   if $purge_hosts_type == 'string' {
     $purge_hosts_enabled = str2bool($purge_hosts)
@@ -120,7 +128,7 @@ class hosts (
     ip           => $localhost6_ip,
   }
 
-  if $use_fqdn == true {
+  if $use_fqdn_real == true {
     @@host { $::fqdn:
       ensure       => $fqdn_ensure,
       host_aliases => $my_fqdn_host_aliases,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,6 +7,7 @@ class hosts (
   $enable_ipv4_localhost = true,
   $enable_ipv6_localhost = true,
   $enable_fqdn_entry     = true,
+  $use_fqdn              = true,
   $fqdn_host_aliases     = $::hostname,
   $localhost_aliases     = ['localhost',
                             'localhost4',
@@ -119,20 +120,22 @@ class hosts (
     ip           => $localhost6_ip,
   }
 
-  @@host { $::fqdn:
-    ensure       => $fqdn_ensure,
-    host_aliases => $my_fqdn_host_aliases,
-    ip           => $fqdn_ip,
-  }
-
-  case $collect_all_real {
-    # collect all the exported Host resources
-    true:  {
-      Host <<| |>>
+  if $use_fqdn == true {
+    @@host { $::fqdn:
+      ensure       => $fqdn_ensure,
+      host_aliases => $my_fqdn_host_aliases,
+      ip           => $fqdn_ip,
     }
-    # only collect the exported entry above
-    default: {
-      Host <<| title == $::fqdn |>>
+
+    case $collect_all_real {
+      # collect all the exported Host resources
+      true:  {
+        Host <<| |>>
+      }
+      # only collect the exported entry above
+      default: {
+        Host <<| title == $::fqdn |>>
+      }
     }
   }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -175,6 +175,99 @@ describe 'hosts' do
     end
   end
 
+  describe 'with \'use_fqdn\' parameter set to' do
+    [false, 'false'].each do |use_fqdn_value|
+      context "#{use_fqdn_value}" do
+        let(:params) { { :use_fqdn => use_fqdn_value } }
+        let(:facts) {
+          { :hostname  => 'monkey',
+            :ipaddress => '10.1.2.3',
+            :fqdn      => 'monkey.example.com',
+          }
+        }
+
+        it {
+          should contain_host('localhost').with({
+            'ensure' => 'absent',
+            'target' => '/etc/hosts',
+          })
+        }
+
+        it {
+          should contain_host('localhost.localdomain').with({
+            'ensure'       => 'present',
+            'host_aliases' => ['localhost', 'localhost4', 'localhost4.localdomain4'],
+            'ip'           => '127.0.0.1',
+            'target'       => '/etc/hosts',
+          })
+        }
+
+        it {
+          should contain_host('localhost6.localdomain6').with({
+            'ensure'       => 'present',
+            'host_aliases' => ['localhost6', 'localhost6.localdomain6'],
+            'ip'           => '::1',
+            'target'       => '/etc/hosts',
+          })
+        }
+
+        it { should_not contain_host('monkey.example.com') }
+
+        it { should contain_resources('host').with({'purge' => 'false'}) }
+      end
+    end
+  end
+
+  describe 'with \'use_fqdn\' parameter set to' do
+    [true,'true'].each do |use_fqdn_value|
+      context "#{use_fqdn_value}" do
+        let(:params) { { :use_fqdn => use_fqdn_value } }
+        let(:facts) {
+          { :hostname  => 'monkey',
+            :ipaddress => '10.1.2.3',
+            :fqdn      => 'monkey.example.com',
+          }
+        }
+
+        it {
+          should contain_host('localhost').with({
+            'ensure' => 'absent',
+            'target' => '/etc/hosts',
+          })
+        }
+
+        it {
+          should contain_host('localhost.localdomain').with({
+            'ensure'       => 'present',
+            'host_aliases' => ['localhost', 'localhost4', 'localhost4.localdomain4'],
+            'ip'           => '127.0.0.1',
+            'target'       => '/etc/hosts',
+          })
+        }
+
+        it {
+          should contain_host('localhost6.localdomain6').with({
+            'ensure'       => 'present',
+            'host_aliases' => ['localhost6', 'localhost6.localdomain6'],
+            'ip'           => '::1',
+            'target'       => '/etc/hosts',
+          })
+        }
+
+#        # GH: rspec-puppet does not yet support checking for exported resources
+#        it {
+#          should contain_host('monkey.example.com').with({
+#            'ensure'       => 'present',
+#            'host_aliases' => ['monkey'],
+#            'ip'           => '10.1.2.3',
+#          })
+#        }
+
+        it { should contain_resources('host').with({'purge' => 'false'}) }
+      end
+    end
+  end
+
   describe 'with \'localhost_aliases\' parameter set to' do
     context 'single value' do
       let(:params) { { :localhost_aliases => 'home' } }


### PR DESCRIPTION
andrewbastien:

The use_fqdn param doesn't affect the localhost entries, only the entry for the nodes own fqdn. It is useful when the fqdn determined by the $::fqdn fact doesn't resolve to the ip address that you want to include in the hosts file. For example, when your node has both a public and private ip address, the dns record points to the public address, and you want to include the private address in /etc/hosts.

One option to using the use_fqdn parameter could be to change the fqdn_entry_enabled parameter to not define the Host value for the local node instead of defining it and setting ensure => absent.

But regardless of how it is implemented, the module should have the ability to override how or whether it includes a node's fqdn in /etc/hosts.

We need this capability so our boost nodes can connect to each other by hostname over infiniband. Without it we have to put in every node's yaml file host::host_entries for all the boost nodes except for it's own. With it, we can just put them all in the role file. So we only have to manage one file and 60 entries instead of 60 files and 3540 entries.
