### PR TITLE
Fix for removing fqdn entry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 1.8.7
   - 1.9.3
   - 2.0.0
+  - 2.1.0
 
 env:
   matrix:
@@ -25,6 +26,14 @@ matrix:
   exclude:
     - rvm: 2.0.0
       env: PUPPET_GEM_VERSION="~> 3.1.0"
+    - rvm: 2.1.0
+      env: PUPPET_GEM_VERSION="~> 3.1.0"
+    - rvm: 2.1.0
+      env: PUPPET_GEM_VERSION="~> 3.2.0"
+    - rvm: 2.1.0
+      env: PUPPET_GEM_VERSION="~> 3.3.0"
+    - rvm: 2.1.0
+      env: PUPPET_GEM_VERSION="~> 3.4.0"
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,30 @@
 ---
-env:
-- PUPPET_VERSION=3.3.2
-- PUPPET_VERSION=3.4.2
-- PUPPET_VERSION=3.5.1
-- PUPPET_VERSION=3.6.0
-notifications:
-email: false
-rvm:
-- 1.8.7
-- 1.9.3
-- 2.0.0
 language: ruby
-before_script: "gem install --no-ri --no-rdoc bundler"
+
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+
+env:
+  matrix:
+    - PUPPET_GEM_VERSION="~> 3.1.0"
+    - PUPPET_GEM_VERSION="~> 3.2.0"
+    - PUPPET_GEM_VERSION="~> 3.3.0"
+    - PUPPET_GEM_VERSION="~> 3.4.0"
+    - PUPPET_GEM_VERSION="~> 3.5.1"
+    - PUPPET_GEM_VERSION="~> 3.6.0"
+    - PUPPET_GEM_VERSION="~> 3.7.0"
+
+sudo: false
+
 script: 'bundle exec rake validate && bundle exec rake lint && SPEC_OPTS="--format documentation" bundle exec rake spec'
-gemfile: Gemfile
+
+matrix:
+  fast_finish: true
+  exclude:
+    - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="~> 3.1.0"
+
+notifications:
+  email: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,11 @@
 source 'https://rubygems.org'
 
-puppetversion = ENV.key?('PUPPET_VERSION') ? "= #{ENV['PUPPET_VERSION']}" : ['>= 3.3']
-gem 'puppet', puppetversion
+if puppetversion = ENV['PUPPET_GEM_VERSION']
+  gem 'puppet', puppetversion, :require => false
+else
+  gem 'puppet', :require => false
+end
+
 gem 'puppetlabs_spec_helper', '>= 0.1.0'
 gem 'puppet-lint', '>= 1.0.0'
 gem 'facter', '>= 1.7.0'

--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,8 @@ gem 'puppetlabs_spec_helper', '>= 0.1.0'
 gem 'puppet-lint', '>= 1.0.0'
 gem 'facter', '>= 1.7.0'
 gem 'rspec-puppet', '~>1.0'
+
+# rspec must be v2 for ruby 1.8.7
+if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
+  gem 'rspec', '~> 2.0'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ puppetversion = ENV.key?('PUPPET_VERSION') ? "= #{ENV['PUPPET_VERSION']}" : ['>=
 gem 'puppet', puppetversion
 gem 'puppetlabs_spec_helper', '>= 0.1.0'
 gem 'puppet-lint', '>= 0.3.2'
-gem 'facter', '>= 1.7.0', "< 1.8.0"
+gem 'facter', '>= 1.7.0'
 gem 'rspec-puppet', '~>1.0'

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source 'https://rubygems.org'
 puppetversion = ENV.key?('PUPPET_VERSION') ? "= #{ENV['PUPPET_VERSION']}" : ['>= 3.3']
 gem 'puppet', puppetversion
 gem 'puppetlabs_spec_helper', '>= 0.1.0'
-gem 'puppet-lint', '>= 0.3.2'
+gem 'puppet-lint', '>= 1.0.0'
 gem 'facter', '>= 1.7.0'
 gem 'rspec-puppet', '~>1.0'

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gem 'puppet', puppetversion
 gem 'puppetlabs_spec_helper', '>= 0.1.0'
 gem 'puppet-lint', '>= 0.3.2'
 gem 'facter', '>= 1.7.0', "< 1.8.0"
+gem 'rspec-puppet', '~>1.0'

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2010-2013 Garrett Honeycutt <code@garretthoneycutt.com>
+Copyright (C) 2010-2015 Garrett Honeycutt <code@garretthoneycutt.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ and optionally purge unmanaged entries.
 
 # Compatibility
 
-This module targets Puppet v3. It should work with any *nix based system that uses `/etc/hosts`.
+This module targets Puppet v3 with Ruby versions 1.8.7, 1.9.3, 2.0.0 and 2.1.0. It should work with any *nix based system that uses `/etc/hosts`.
 
 ===
 

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ PuppetLint.configuration.send('disable_80chars')
 PuppetLint.configuration.relative = true
 PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
 
-desc "Run puppet in noop mode and check for syntax errors."
+desc 'Validate manifests, templates, and ruby files'
 task :validate do
   Dir['manifests/**/*.pp'].each do |manifest|
     sh "puppet parser validate --noop #{manifest}"

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.relative = true
 PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
 
 desc "Run puppet in noop mode and check for syntax errors."

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -104,8 +104,8 @@ class hosts (
     $fqdn_ip              = $::ipaddress
   } else {
     $fqdn_ensure          = 'absent'
-    $my_fqdn_host_aliases = ''
-    $fqdn_ip              = ''
+    $my_fqdn_host_aliases = []
+    $fqdn_ip              = $::ipaddress
   }
 
   Host {


### PR DESCRIPTION
Without this patch, if you went from the default of having the fqdn
present in the hosts file and set enable_fqdn_entry to false, there
would be an error instead of removing the entry.