### PR TITLE
Add fqdn_ip_address parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ String or Array of aliases for fqdn
 
 - *Default*: $::hostname
 
+fqdn_ip_address
+---------------
+String with IP address for fqdn
+
+- *Default*: $::ipaddress
+
 localhost_aliases
 -----------------
 String or Array of aliases for localhost

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -91,6 +91,10 @@ class hosts (
     fail('hosts::localhost6_aliases must be a string or an array.')
   }
 
+  if !is_ip_address($fqdn_ip_address) {
+    fail('hosts::fqdn_ip_address must be an IP address')
+  }
+
   if $fqdn_entry_enabled == true {
     $fqdn_ensure          = 'present'
     $my_fqdn_host_aliases = $fqdn_host_aliases

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,7 @@ class hosts (
   $enable_fqdn_entry     = true,
   $use_fqdn              = true,
   $fqdn_host_aliases     = $::hostname,
+  $fqdn_ip_address       = $::ipaddress,
   $localhost_aliases     = ['localhost',
                             'localhost4',
                             'localhost4.localdomain4'],
@@ -93,11 +94,11 @@ class hosts (
   if $fqdn_entry_enabled == true {
     $fqdn_ensure          = 'present'
     $my_fqdn_host_aliases = $fqdn_host_aliases
-    $fqdn_ip              = $::ipaddress
+    $fqdn_ip              = $fqdn_ip_address
   } else {
     $fqdn_ensure          = 'absent'
     $my_fqdn_host_aliases = []
-    $fqdn_ip              = $::ipaddress
+    $fqdn_ip              = $fqdn_ip_address
   }
 
   Host {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "ghoneycutt-hosts",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "author": "ghoneycutt",
   "summary": "Manages host entries",
   "license": "Apache-2.0",
@@ -10,7 +10,7 @@
   "requirements": [
     {
       "name": "pe",
-      "version_requirement": "3.2.x"
+      "version_requirement": "3.x"
     },
     {
       "name": "puppet",

--- a/metadata.json
+++ b/metadata.json
@@ -1,8 +1,9 @@
 {
   "name": "ghoneycutt-hosts",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "author": "ghoneycutt",
   "summary": "Manages host entries",
+  "description": "Can ensure entries for localhost, localhost6, and $::fqdn,\nincluding aliases and optionally purge unmanaged entries.",
   "license": "Apache-2.0",
   "source": "git://github.com/ghoneycutt/puppet-module-hosts.git",
   "project_page": "https://github.com/ghoneycutt/puppet-module-hosts",
@@ -46,8 +47,7 @@
       "operatingsystem": "Ubuntu"
     }
   ],
-  "description": "Can ensure entries for localhost, localhost6, and $::fqdn,\nincluding aliases and optionally purge unmanaged entries.",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 3.2.0 < 5.0.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 3.2.0 < 6.0.0"}
   ]
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 describe 'hosts' do
+  let(:facts) { { :ipaddress => '10.1.2.3',} }
 
   it { should compile.with_all_deps }
 
@@ -264,6 +265,27 @@ describe 'hosts' do
 #        }
 
         it { should contain_resources('host').with({'purge' => 'false'}) }
+      end
+    end
+  end
+
+  describe 'with \'fqdn_ip_address\' parameter set to' do
+    context 'an invalid type (not ip address)' do
+      let(:params) { 
+        { :fqdn_ip_address => 'wrong.ip.address',
+        } 
+      }
+      let(:facts) {
+        { :hostname  => 'monkey',
+          :ipaddress => '10.1.2.3',
+          :fqdn      => 'monkey.example.com',
+        }
+      }
+
+      it 'should fail' do
+        expect {
+          should contain_class('hosts')
+        }.to raise_error(Puppet::Error,/hosts::fqdn_ip_address must be an IP address./)
       end
     end
   end
@@ -541,6 +563,7 @@ describe 'hosts' do
         'host_aliases' => ['myhost2','loghost'],
       },
     } } }
+    let(:facts) { { :ipaddress => '10.1.2.3' } }
 
     it {
       should contain_host('myhost.example.com').with({
@@ -558,8 +581,9 @@ describe 'hosts' do
   end
 
   context 'with host_entries containing post for fqdn' do
-    let(:facts) { { :fqdn => 'myhost.example.com',
-                    :ip   => '10.0.0.5',} }
+    let(:facts) { { :fqdn      => 'myhost.example.com',
+                    :ip        => '10.0.0.5',
+                    :ipaddress => '10.1.2.3',} }
     let(:params) {
       { :host_entries => {
           'myhost.example.com' => {


### PR DESCRIPTION
As proposed in issue #35, a fqdn ip address parameter could be used to set fqdn entry with a different IP than eth0 IP. It can ve useful in case there are two or more interfaces.
By default, fqdn is set to ::ipaddress fact.
