### PR TITLE
Remove specified target

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -108,6 +108,12 @@ class hosts (
     host_aliases => $my_localhost_aliases,
     ip           => $localhost_ip,
   }
+  
+  host { "${::fqdn}" :
+    ensure       => $localhost_ensure,
+    host_aliases => $my_fqdn_host_aliases,
+    ip           => '127.0.1.1',
+  }
 
   host { 'localhost6.localdomain6':
     ensure       => $localhost6_ensure,
@@ -116,9 +122,9 @@ class hosts (
   }
 
   if $use_fqdn_real == true {
-    @@host { $::fqdn:
+    @@host { "${::hostname}":
       ensure       => $fqdn_ensure,
-      host_aliases => $my_fqdn_host_aliases,
+      host_aliases => $::fqdn,
       ip           => $fqdn_ip,
     }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,6 @@ class hosts (
   $localhost6_aliases    = ['localhost6',
                             'localhost6.localdomain6'],
   $purge_hosts           = false,
-  $target                = '/etc/hosts',
   $host_entries          = undef,
 ) {
 
@@ -98,10 +97,6 @@ class hosts (
     $fqdn_ensure          = 'absent'
     $my_fqdn_host_aliases = []
     $fqdn_ip              = $::ipaddress
-  }
-
-  Host {
-    target => $target,
   }
 
   host { 'localhost':


### PR DESCRIPTION
Since the host types have sane default targets for *nix and Windows operating systems, this module can be used cross platform if this target is not hard coded. If this functionality is desired however, this can still be established with resource defaults set elsewhere (such as site.pp)