### PR TITLE
Move comments to correct context in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,10 +12,9 @@ gem 'facter', '>= 1.7.0'
 gem 'rspec-puppet'
 gem 'puppet-lint'
 
-# rspec must be v2 for ruby 1.8.7
 if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
   # rake >=11 does not support ruby 1.8.7
   gem 'rake', '~> 10.0'
+  # rspec must be v2 for ruby 1.8.7
   gem 'rspec', '~> 2.0'
 end
-


### PR DESCRIPTION
Moving comments to the correct context will enhance the readability.