### PR TITLE
fix fqdn entry not being created

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -121,7 +121,7 @@ class hosts (
   }
 
   if $use_fqdn_real == true {
-    @@host { $::fqdn:
+    host { $::fqdn:
       ensure       => $fqdn_ensure,
       host_aliases => $my_fqdn_host_aliases,
       ip           => $fqdn_ip,


### PR DESCRIPTION
removed the `@@` characters that were preventing the fqdn entry to be setup when required.