### PR TITLE
Added support for filtering exported hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,18 @@ Boolean to optionally collect all the exported Host resources
 
 - *Default*: false
 
+collect_tag
+-----------
+String to filter the collection of exported Host resources.
+
+- *Default*: undef
+
+export_tag
+----------
+String or Array of tag(s) to attach to the exported Host resource.
+
+- *Default*: undef
+
 host_entries
 ------------
 Hash of host entries

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -133,6 +133,8 @@ class hosts (
   }
 
   if $use_fqdn_real == true {
+    # the Host resource is duplicated because in certain combinations
+    # of Ruby and Puppet it's not possible to have an empty/undef tag
     if $export_tag == undef {
       @@host { $::fqdn:
         ensure       => $fqdn_ensure,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,6 +29,16 @@ class hosts (
     $collect_all_real = $collect_all
   }
 
+  # validate type
+  if $collect_tag != undef and !is_string($collect_tag) {
+    fail('hosts::collect_tag must be a string.')
+  }
+
+  # validate type
+  if $export_tag != undef and !is_string($export_tag) and !is_array($export_tag) {
+    fail('hosts::export_tag must be a string or an array.')
+  }
+
   # validate type and convert string to boolean if necessary
   if is_string($enable_ipv4_localhost) {
     $ipv4_localhost_enabled = str2bool($enable_ipv4_localhost)
@@ -123,11 +133,19 @@ class hosts (
   }
 
   if $use_fqdn_real == true {
-    @@host { $::fqdn:
-      ensure       => $fqdn_ensure,
-      host_aliases => $my_fqdn_host_aliases,
-      ip           => $fqdn_ip,
-      tag          => $export_tag,
+    if $export_tag == undef {
+      @@host { $::fqdn:
+        ensure       => $fqdn_ensure,
+        host_aliases => $my_fqdn_host_aliases,
+        ip           => $fqdn_ip,
+      }
+    } else {
+      @@host { $::fqdn:
+        ensure       => $fqdn_ensure,
+        host_aliases => $my_fqdn_host_aliases,
+        ip           => $fqdn_ip,
+        tag          => $export_tag,
+      }
     }
 
     case $collect_all_real {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,8 @@
 #
 class hosts (
   $collect_all           = false,
+  $collect_tag           = undef,
+  $export_tag            = undef,
   $enable_ipv4_localhost = true,
   $enable_ipv6_localhost = true,
   $enable_fqdn_entry     = true,
@@ -125,12 +127,17 @@ class hosts (
       ensure       => $fqdn_ensure,
       host_aliases => $my_fqdn_host_aliases,
       ip           => $fqdn_ip,
+      tag          => $export_tag,
     }
 
     case $collect_all_real {
       # collect all the exported Host resources
       true:  {
-        Host <<| |>>
+        if $collect_tag == undef {
+            Host <<| |>>
+        } else {
+            Host <<| tag == $collect_tag |>>
+        }
       }
       # only collect the exported entry above
       default: {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -598,4 +598,31 @@ describe 'hosts' do
       }.to raise_error(Puppet::Error)
     end
   end
+
+  describe 'with \'collect_tag\' specified as not of type string' do
+    [true, false, { 'a' => 'b' }, [ 'a', 'b']].each do |collect_tag_value|
+      context "#{collect_tag_value}" do
+        let(:params) { { :collect_tag => collect_tag_value } }
+
+        it 'should fail' do
+          expect {
+            should contain_class('hosts')
+          }.to raise_error(Puppet::Error)
+        end
+      end
+    end
+  end
+  describe 'with \'export_tag\' specified as not of type string or array' do
+    [true, false, { 'a' => 'b' }].each do |export_tag_value|
+      context "#{export_tag_value}" do
+        let(:params) { { :export_tag => export_tag_value } }
+
+        it 'should fail' do
+          expect {
+            should contain_class('hosts')
+          }.to raise_error(Puppet::Error)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Allows for attaching arbitrary tags to exported resources, and collecting only exported resources matching a specific tag

Signed-off-by: Ricardo Silva ricardo.silva@epfl.ch
