### PR TITLE
Added possibility to use ipaddress_main_interface

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,5 +3,8 @@ fixtures:
     stdlib:
       repo: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
       ref: '4.6.0'
+    stdlibplus:
+      repo: 'https://github.com/juliengk/puppet-stdlibplus.git'
+      ref: 'v0.1.7'
   symlinks:
     hosts: "#{source_dir}"

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ When enabled use the ${::fqdn} fact to determine the hosts entry for the local n
 
 - *Default*: true
 
+use_stdlibplus
+--------------
+When enabled use stdlibplus'es fact ipaddress_main_interface instead of ipaddress, taking into consideration set default routes.
+
+- *Default*: false
+
 fqdn_host_aliases
 -----------------
 String or Array of aliases for fqdn

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,7 @@ class hosts (
   $enable_ipv6_localhost = true,
   $enable_fqdn_entry     = true,
   $use_fqdn              = true,
+  $use_stdlibplus        = false,
   $fqdn_host_aliases     = $::hostname,
   $localhost_aliases     = ['localhost',
                             'localhost4',
@@ -19,6 +20,11 @@ class hosts (
   $host_entries          = undef,
 ) {
 
+  if $use_stdlibplus == true {
+    $ipaddress = $::ipaddress_main_interface
+  } else {
+    $ipaddress = $::ipaddress
+  }
 
   # validate type and convert string to boolean if necessary
   if is_string($collect_all) {
@@ -93,11 +99,11 @@ class hosts (
   if $fqdn_entry_enabled == true {
     $fqdn_ensure          = 'present'
     $my_fqdn_host_aliases = $fqdn_host_aliases
-    $fqdn_ip              = $::ipaddress
+    $fqdn_ip              = $ipaddress
   } else {
     $fqdn_ensure          = 'absent'
     $my_fqdn_host_aliases = []
-    $fqdn_ip              = $::ipaddress
+    $fqdn_ip              = $ipaddress
   }
 
   Host {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -49,6 +49,53 @@ describe 'hosts' do
     it { should contain_resources('host').with({'purge' => 'false'}) }
   end
 
+  context 'with default parameter settings and stdlibplus' do
+    let(:params) { { :use_stdlibplus => true } }
+    let(:facts) {
+      { :hostname                 => 'monkey',
+        :ipaddress                => '10.1.2.3',
+        :ipaddress_main_interface => '10.3.2.1',
+        :fqdn                     => 'monkey.example.com',
+      }
+    }
+
+    it {
+      should contain_host('localhost').with({
+        'ensure' => 'absent',
+        'target' => '/etc/hosts',
+      })
+    }
+
+    it {
+      should contain_host('localhost.localdomain').with({
+        'ensure'       => 'present',
+        'host_aliases' => ['localhost', 'localhost4', 'localhost4.localdomain4'],
+        'ip'           => '127.0.0.1',
+        'target'       => '/etc/hosts',
+      })
+    }
+
+    it {
+      should contain_host('localhost6.localdomain6').with({
+        'ensure'       => 'present',
+        'host_aliases' => ['localhost6', 'localhost6.localdomain6'],
+        'ip'           => '::1',
+        'target'       => '/etc/hosts',
+      })
+    }
+
+#    it {
+#      should contain_host('monkey.example.com').with({
+#        'ensure'      => 'present',
+#        'host_aliases' => ['monkey', 'monkey.example.com'],
+#        'ip'           => '10.3.2.1',
+#        'target'       => '/etc/hosts',
+#      })
+#    }
+
+    it { should contain_resources('host').with({'purge' => 'false'}) }
+  end
+
   describe 'with \'enable_ipv4_localhost\' parameter set to' do
     [false, 'false'].each do |enable_ipv4_localhost_value|
       context "#{enable_ipv4_localhost_value}" do


### PR DESCRIPTION
ipaddress_main_interface is part of stdlibplus and creates a saner
logic in where the default route is taken into consideration when
figuring out which is the primary interface.
The old way would break put interface abc ahead of bdc even though
bdc has the default route set and the other interface only has an ip.