### PR TITLE
Re-adding posibilty of fqdn host entries

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -144,7 +144,11 @@ class hosts (
   }
 
   if $host_entries != undef {
-    $host_entries_real = delete($host_entries,$::fqdn)
+    if $use_fqdn_real == true {
+      $host_entries_real = delete($host_entries,$::fqdn)
+    } else {
+      $host_entries_real = $host_entries
+    }
     validate_hash($host_entries_real)
     create_resources(host,$host_entries_real)
   }


### PR DESCRIPTION
b0de4096530c62c77599199142e476db48a1bfdc filtered out fqdn at all
times, but in some cases we wish to override fqdn entry like when
ipaddress fact doesn't find the correct primary interface.