### PR TITLE
Add stored_config parameter to turn off storedconfigs usage, #49

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,6 +3,7 @@
 # Manage /etc/hosts
 #
 class hosts (
+  $stored_config         = true,
   $collect_all           = false,
   $enable_ipv4_localhost = true,
   $enable_ipv6_localhost = true,
@@ -25,6 +26,13 @@ class hosts (
     $collect_all_real = str2bool($collect_all)
   } else {
     $collect_all_real = $collect_all
+  }
+
+  # validate type and convert string to boolean if necessary
+  if is_string($stored_config) {
+    $stored_config_real = str2bool($stored_config)
+  } else {
+    $stored_config_real = $stored_config
   }
 
   # validate type and convert string to boolean if necessary
@@ -121,20 +129,28 @@ class hosts (
   }
 
   if $use_fqdn_real == true {
-    @@host { $::fqdn:
-      ensure       => $fqdn_ensure,
-      host_aliases => $my_fqdn_host_aliases,
-      ip           => $fqdn_ip,
-    }
-
-    case $collect_all_real {
-      # collect all the exported Host resources
-      true:  {
-        Host <<| |>>
+    if $stored_config_real == true {
+      @@host { $::fqdn:
+        ensure       => $fqdn_ensure,
+        host_aliases => $my_fqdn_host_aliases,
+        ip           => $fqdn_ip,
       }
-      # only collect the exported entry above
-      default: {
-        Host <<| title == $::fqdn |>>
+  
+      case $collect_all_real {
+        # collect all the exported Host resources
+        true:  {
+          Host <<| |>>
+        }
+        # only collect the exported entry above
+        default: {
+          Host <<| title == $::fqdn |>>
+        }
+      }
+    } else {
+      host { $::fqdn:
+        ensure       => $fqdn_ensure,
+        host_aliases => $my_fqdn_host_aliases,
+        ip           => $fqdn_ip,
       }
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -135,7 +135,6 @@ class hosts (
         host_aliases => $my_fqdn_host_aliases,
         ip           => $fqdn_ip,
       }
-  
       case $collect_all_real {
         # collect all the exported Host resources
         true:  {


### PR DESCRIPTION
Stored configs are not always available, and never if using puppet apply.  Not only does the current manifest cause a warning, the main host entry is not created/removed.
This PR wraps the existing logic in a parameter 'stored_config' parameter and keeps current behaviour by default (stored_config=true).  But if stored_config is set to false, it falls back to normal non-storedconfigs behaviour and works as expected.