### PR TITLE
Update purge_hosts to use correct variable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -140,7 +140,7 @@ class hosts (
   }
 
   resources { 'host':
-    purge => $purge_hosts,
+    purge => $purge_hosts_enabled,
   }
 
   if $host_entries != undef {


### PR DESCRIPTION
Not a very bad bug, but just wanted to let you know.